### PR TITLE
fix warnings in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,10 @@ lazy val root = (project in file ("."))
         "-unchecked",
         "-Xfuture"
       ),
-      scalacOptions in (Compile, doc) ++= {
+      Compile / doc / scalacOptions ++= {
         Seq(
           "-sourcepath",
-          (baseDirectory in LocalRootProject).value.getAbsolutePath,
+          (LocalRootProject / baseDirectory).value.getAbsolutePath,
           "-doc-source-url",
           s"""https://github.com/flyway/flyway-sbt/tree/${sys.process.Process("git rev-parse HEAD").lineStream_!.head}€{FILE_PATH}.scala"""
         )


### PR DESCRIPTION
```
flyway-sbt/build.sbt:18: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
      scalacOptions in (Compile, doc) ++= {
                    ^
flyway-sbt/build.sbt:21: warning: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
          (baseDirectory in LocalRootProject).value.getAbsolutePath,
                         ^
```